### PR TITLE
Fix crash when day of week is Sunday

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -40,7 +40,7 @@ pub trait CredentialFields {
 
 pub trait CredentialStore<T> {
     fn add(&self, credential: T);
-    fn get(&self) -> RwLockReadGuard<Vec<Arc<T>>>;
+    fn get(&self) -> RwLockReadGuard<'_, Vec<Arc<T>>>;
 }
 
 #[derive(Debug)]
@@ -64,7 +64,7 @@ impl<T: CredentialFields> CredentialStore<T> for MockCredentialStore<T> {
             .expect("Rwlock poisoned in MockCredentialStore add method");
         store.push(Arc::new(credential))
     }
-    fn get(&self) -> RwLockReadGuard<Vec<Arc<T>>> {
+    fn get(&self) -> RwLockReadGuard<'_, Vec<Arc<T>>> {
         self.inner
             .read()
             .expect("Rwlock poisoned in MockCredentialStore get method")

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -234,17 +234,8 @@ unsafe fn get_last_written(last_written: FILETIME) -> HumanTime {
     let mut local_filetime: FILETIME = std::mem::zeroed();
     let mut system_time: SYSTEMTIME = std::mem::zeroed();
     let local: TIME_ZONE_INFORMATION = std::mem::zeroed();
-
-    let rc1 = FileTimeToLocalFileTime(&last_written, &mut local_filetime as *mut FILETIME);
-    let rc2 = LocalFileTimeToLocalSystemTime(
-        &local,
-        &local_filetime,
-        &mut system_time as *mut SYSTEMTIME,
-    );
-    println!(
-        "DEBUG: rc1: {rc1}, rc2: {rc2}, yyyy-mm-dd: {}.{}.{}, day_of_week: {}",
-        system_time.wYear, system_time.wMonth, system_time.wDay, system_time.wDayOfWeek
-    );
+    FileTimeToLocalFileTime(&last_written, &mut local_filetime as *mut FILETIME);
+    LocalFileTimeToLocalSystemTime(&local, &local_filetime, &mut system_time as *mut SYSTEMTIME);
     HumanTime {
         hour: system_time.wHour,
         minute: system_time.wMinute,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,14 +10,17 @@ use windows_sys::Win32::System::Time::{LocalFileTimeToLocalSystemTime, TIME_ZONE
 use super::error::{Error as ErrorCode, Result};
 use super::search::{CredentialSearch, CredentialSearchApi, CredentialSearchResult};
 
+// On Windows, the days of the week are 0-based (Sunday = 0)
+// while the months are 1-based (January = 1).
+// See https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime
 static DAYS: [&str; 7] = [
+    "Sunday",
     "Monday",
     "Tuesday",
     "Wednesday",
     "Thursday",
     "Friday",
     "Saturday",
-    "Sunday",
 ];
 static MONTHS: [&str; 12] = [
     "January",
@@ -231,6 +234,7 @@ unsafe fn get_last_written(last_written: FILETIME) -> HumanTime {
     let mut local_filetime: FILETIME = std::mem::zeroed();
     let mut system_time: SYSTEMTIME = std::mem::zeroed();
     let local: TIME_ZONE_INFORMATION = std::mem::zeroed();
+
     let rc1 = FileTimeToLocalFileTime(&last_written, &mut local_filetime as *mut FILETIME);
     let rc2 = LocalFileTimeToLocalSystemTime(
         &local,
@@ -245,7 +249,7 @@ unsafe fn get_last_written(last_written: FILETIME) -> HumanTime {
         hour: system_time.wHour,
         minute: system_time.wMinute,
         second: system_time.wSecond,
-        day_of_week: DAYS[system_time.wDayOfWeek as usize - 1].to_string(),
+        day_of_week: DAYS[system_time.wDayOfWeek as usize].to_string(),
         day: system_time.wDay,
         month: MONTHS[system_time.wMonth as usize - 1].to_string(),
         year: system_time.wYear,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -475,4 +475,109 @@ mod tests {
             "Returned an empty value"
         );
     }
+
+    #[test]
+    fn last_written_filetime() {
+        // Generate set of FILETIME values to cover all months and days and
+        // confirm "day_of_week" and "month" strings are correct.
+        // Use 12:00pm UTC to make sure timezone differences are accounted for.
+        // The year 2020 had first day of each month covering all days of the week.
+        // The hex values were generated from
+        // https://www.silisoftware.com/tools/date.php?inputdate=jan+1+2020+12%3A00&inputformat=text
+        let test_filetimes: Vec<FILETIME> = vec![
+            FILETIME {
+                dwLowDateTime: 0xFE39E000,
+                dwHighDateTime: 0x01D5C09A,
+            }, // Jan 1, 2020 Wed
+            FILETIME {
+                dwLowDateTime: 0x21082000,
+                dwHighDateTime: 0x01D5D8F7,
+            }, // Feb 1, 2020 Sat
+            FILETIME {
+                dwLowDateTime: 0xEF02E000,
+                dwHighDateTime: 0x01D5EFC0,
+            }, // Mar 1, 2020 Sun
+            FILETIME {
+                dwLowDateTime: 0x11D12000,
+                dwHighDateTime: 0x01D6081D,
+            }, // Apr 1, 2020 Wed
+            FILETIME {
+                dwLowDateTime: 0x0A35A000,
+                dwHighDateTime: 0x01D61FB0,
+            }, // May 1, 2020 Fri
+            FILETIME {
+                dwLowDateTime: 0x2D03E000,
+                dwHighDateTime: 0x01D6380C,
+            }, // Jun 1, 2020 Mon
+            FILETIME {
+                dwLowDateTime: 0x25686000,
+                dwHighDateTime: 0x01D64F9F,
+            }, // Jul 1, 2020 Wed
+            FILETIME {
+                dwLowDateTime: 0x4836A000,
+                dwHighDateTime: 0x01D667FB,
+            }, // Aug 1, 2020 Sat
+            FILETIME {
+                dwLowDateTime: 0x6B04E000,
+                dwHighDateTime: 0x01D68057,
+            }, // Sep 1, 2020 Tue
+            FILETIME {
+                dwLowDateTime: 0x63696000,
+                dwHighDateTime: 0x01D697EA,
+            }, // Oct 1, 2020 Thu
+            FILETIME {
+                dwLowDateTime: 0x8637A000,
+                dwHighDateTime: 0x01D6B046,
+            }, // Nov 1, 2020 Sun
+            FILETIME {
+                dwLowDateTime: 0x7E9C2000,
+                dwHighDateTime: 0x01D6C7D9,
+            }, // Dec 1, 2020 Tue
+        ];
+        let expected_months: Vec<&str> = vec![
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
+        ];
+        let expected_day_of_weeks: Vec<&str> = vec![
+            "Wednesday",
+            "Saturday",
+            "Sunday",
+            "Wednesday",
+            "Friday",
+            "Monday",
+            "Wednesday",
+            "Saturday",
+            "Tuesday",
+            "Thursday",
+            "Sunday",
+            "Tuesday",
+        ];
+        for (i, ft) in test_filetimes.iter().enumerate() {
+            let human_time = unsafe { get_last_written(*ft) };
+            println!("Testing FILETIME  {}", human_time.to_string());
+            assert_eq!(
+                human_time.month, expected_months[i],
+                "Month string does not match expected value"
+            );
+            assert_eq!(
+                human_time.day_of_week, expected_day_of_weeks[i],
+                "Day of week string does not match expected value"
+            );
+            assert_eq!(
+                human_time.year, 2020,
+                "Year does not match expected value of 2020"
+            );
+            assert_eq!(human_time.day, 1, "Day does not match expected value of 1");
+        }
+    }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -237,7 +237,10 @@ unsafe fn get_last_written(last_written: FILETIME) -> HumanTime {
         &local_filetime,
         &mut system_time as *mut SYSTEMTIME,
     );
-    println!("DEBUG: rc1: {rc1}, rc2: {rc2}");
+    println!(
+        "DEBUG: rc1: {rc1}, rc2: {rc2}, yyyy-mm-dd: {}.{}.{}, day_of_week: {}",
+        system_time.wYear, system_time.wMonth, system_time.wDay, system_time.wDayOfWeek
+    );
     HumanTime {
         hour: system_time.wHour,
         minute: system_time.wMinute,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -231,8 +231,13 @@ unsafe fn get_last_written(last_written: FILETIME) -> HumanTime {
     let mut local_filetime: FILETIME = std::mem::zeroed();
     let mut system_time: SYSTEMTIME = std::mem::zeroed();
     let local: TIME_ZONE_INFORMATION = std::mem::zeroed();
-    FileTimeToLocalFileTime(&last_written, &mut local_filetime as *mut FILETIME);
-    LocalFileTimeToLocalSystemTime(&local, &local_filetime, &mut system_time as *mut SYSTEMTIME);
+    let rc1 = FileTimeToLocalFileTime(&last_written, &mut local_filetime as *mut FILETIME);
+    let rc2 = LocalFileTimeToLocalSystemTime(
+        &local,
+        &local_filetime,
+        &mut system_time as *mut SYSTEMTIME,
+    );
+    println!("DEBUG: rc1: {rc1}, rc2: {rc2}");
     HumanTime {
         hour: system_time.wHour,
         minute: system_time.wMinute,


### PR DESCRIPTION
The array to define day of week should start with "Sunday" per https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime. The current code works all right only if the "Last Written" date was not on a Sunday. It crashes when the date falls on a Sunday.