### PR TITLE
Fix clippy::question_mark lint in windows.rs

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -99,10 +99,7 @@ impl CredentialSearchApi for WinCredentialSearch {
     ///     let results = search.by_user("Mr. Foo Bar");
     fn by(&self, by: &str, query: &str) -> CredentialSearchResult {
         let mut count = 0;
-        let results = match search_type(by, query) {
-            Ok(results) => results,
-            Err(err) => return Err(err),
-        };
+        let results = search_type(by, query)?;
 
         let mut outer_map: HashMap<String, HashMap<String, String>> = HashMap::new();
         for result in results {


### PR DESCRIPTION
Replace match on search_type() result with the ? operator. Both
search_type() and by() share the same Error type, so a direct ?
is valid and satisfies the clippy::question_mark lint enforced in CI.

https://claude.ai/code/session_0115Q8skmUfDWwDd6MHiv3Tr