### PR TITLE
Add GitHub Actions workflow to publish crate to crates.io on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch head
+        uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crate
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Triggers on `release: published` events and runs `cargo publish`
using the CARGO_REGISTRY_TOKEN repository secret.

https://claude.ai/code/session_01XdaxxN8rRLM2Du2bZ4Fwju